### PR TITLE
Store possible failure status in testCase.result

### DIFF
--- a/src/main/QRPGLESRC/IBMIUNIT.rpgle
+++ b/src/main/QRPGLESRC/IBMIUNIT.rpgle
@@ -940,6 +940,7 @@ dcl-proc runTests;
 
             callUiCase( ui.testSetup : testCase );
             status = callProcedure( testSuite.testSetupProcedure );
+            testCase.result = status;                             
 
             if ( status = RESULT_SUCCESSFUL );
 


### PR DESCRIPTION
Fixes issue #11. Previously, if setup returned failure status, the result was ignored and the test was marked as successful without having been run.

Note -- I have been unable to get the `build` script working smoothly, so that likely needs to be done to update the SAVF.